### PR TITLE
Migrations Uuid Support

### DIFF
--- a/src/MigrationsUuid/2019_01_13_161448_create_properties_table.php
+++ b/src/MigrationsUuid/2019_01_13_161448_create_properties_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePropertiesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('properties', function (Blueprint $table) {
+            $table->string('key', 32)->unique();
+            $table->string('type')->nullable();
+            $table->string('group')->nullable();
+            $table->json('targets')->nullable();
+            $table->json('default');
+            $table->timestamps();
+
+            $table->index(['key', 'type', 'group']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('properties');
+    }
+}

--- a/src/MigrationsUuid/2019_01_13_161513_create_propertyables_table.php
+++ b/src/MigrationsUuid/2019_01_13_161513_create_propertyables_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePropertyablesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('propertyables', function (Blueprint $table) {
+            $table->string('property_key', 32);
+            $table->uuid('propertyable_id');
+            $table->string('propertyable_type');
+            $table->json('value')->nullable();
+            $table->timestamps();
+
+            $table->index(['property_key']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('propertyables');
+    }
+}

--- a/src/PropertiesServiceProvider.php
+++ b/src/PropertiesServiceProvider.php
@@ -39,5 +39,10 @@ class PropertiesServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/Migrations' => database_path('migrations'),
         ], 'migrations');
+        
+        $this->publishes([
+            __DIR__.'/MigrationsUuid' => database_path('migrations'),
+        ], 'migrations-uuid');
+
     }
 }

--- a/src/PropertiesServiceProvider.php
+++ b/src/PropertiesServiceProvider.php
@@ -39,10 +39,9 @@ class PropertiesServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/Migrations' => database_path('migrations'),
         ], 'migrations');
-        
+
         $this->publishes([
             __DIR__.'/MigrationsUuid' => database_path('migrations'),
         ], 'migrations-uuid');
-
     }
 }


### PR DESCRIPTION
Hi @stephenlake, I've enabled uuid support in this pull request as a proposal. It won't break existing implementations out there as it simply gives the developer the option of creating the propertyables pivot propertyable_id as a uuid db field by publishing the migrations from src/MigrationsUuid.

```bash
php artisan vendor:publish --provider="Properties\PropertiesServiceProvider" --tag="migrations-uuid"
```